### PR TITLE
Update (2024.01.11)

### DIFF
--- a/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/downcallLinker_loongarch_64.cpp
@@ -166,7 +166,7 @@ void DowncallStubGenerator::generate() {
   assert(_abi._shadow_space_bytes == 0, "not expecting shadow space on LoongArch64");
   allocated_frame_size += arg_shuffle.out_arg_bytes();
 
-  bool should_save_return_value = !_needs_return_buffer && _needs_transition;
+  bool should_save_return_value = !_needs_return_buffer;
   RegSpiller out_reg_spiller(_output_registers);
   int spill_offset = -1;
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -8140,6 +8140,27 @@ instruct cmovF_cmpI_reg_reg(regF dst, regF src, mRegI tmp1, mRegI tmp2, cmpOp co
   ins_pipe( pipe_slow );
 %}
 
+instruct cmovD_cmpN_reg_reg(regD dst, regD src, mRegN tmp1, mRegN tmp2, cmpOp cop) %{
+  match(Set dst (CMoveD (Binary cop (CmpN tmp1 tmp2)) (Binary dst src)));
+  ins_cost(200);
+  format %{
+             "CMP$cop  $tmp1, $tmp2\t  @cmovD_cmpN_reg_reg\n"
+             "\tCMOV  $dst, $src \t @cmovD_cmpN_reg_reg"
+         %}
+
+  ins_encode %{
+    Register op1 = $tmp1$$Register;
+    Register op2 = $tmp2$$Register;
+    FloatRegister dst = as_FloatRegister($dst$$reg);
+    FloatRegister src = as_FloatRegister($src$$reg);
+    int     flag = $cop$$cmpcode;
+
+    __ cmp_cmov(op1, op2, dst, src, (MacroAssembler::CMCompare) flag, false /* is_signed */);
+  %}
+
+  ins_pipe( pipe_slow );
+%}
+
 instruct cmovD_cmpI_reg_reg(regD dst, regD src, mRegI tmp1, mRegI tmp2, cmpOp cop) %{
   match(Set dst (CMoveD (Binary cop (CmpI tmp1 tmp2)) (Binary dst src)));
   ins_cost(200);

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -2970,22 +2970,31 @@ void MacroAssembler::cmp_cmov(Register      op1,
                               Register      op2,
                               FloatRegister dst,
                               FloatRegister src,
-                              CMCompare     cmp) {
+                              CMCompare     cmp,
+                              bool          is_signed) {
   switch (cmp) {
     case EQ:
     case NE:
       sub_d(AT, op1, op2);
-      slt(AT, R0, AT);
+      sltu(AT, R0, AT);
       break;
 
     case GT:
     case LE:
-      slt(AT, op2, op1);
+      if (is_signed) {
+        slt(AT, op2, op1);
+      } else {
+        sltu(AT, op2, op1);
+      }
       break;
 
     case GE:
     case LT:
-      slt(AT, op1, op2);
+      if (is_signed) {
+        slt(AT, op1, op2);
+      } else {
+        sltu(AT, op1, op2);
+      }
       break;
 
     default:

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -635,7 +635,8 @@ class MacroAssembler: public Assembler {
                 Register        op2,
                 FloatRegister   dst,
                 FloatRegister   src,
-                CMCompare       cmp = EQ);
+                CMCompare       cmp = EQ,
+                bool      is_signed = true);
 
   void membar(Membar_mask_bits hint);
 


### PR DESCRIPTION
32093: Add CMoveD-CmpN node
31973: LA port of 8313023: Return value corrupted when using CCS + isTrivial (mainline)