### PR TITLE
Update (2024.01.11)

### DIFF
--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -311,9 +311,9 @@ void RegisterSaver::restore_result_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
-// 16 bytes XMM registers are saved by default using fxsave/fxrstor instructions.
+// 8 bytes registers are saved by default using fld/fst instructions.
 bool SharedRuntime::is_wide_vector(int size) {
-  return size > 16;
+  return size > 8;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
32163: The size of is_wide_vector should be greater than 8 bytes