### PR TITLE
Update (2024.01.12)

### DIFF
--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -1155,7 +1155,11 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
 
 // Max vector size in bytes. 0 if not supported.
 const int Matcher::vector_width_in_bytes(BasicType bt) {
-  return (int)MaxVectorSize;
+  int size = (int)MaxVectorSize;
+  if (size < 2*type2aelembytes(bt)) size = 0;
+  // But never < 4
+  if (size < 4) size = 0;
+  return size;
 }
 
 // Limits on vector size (number of elements) loaded into vector.

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -159,7 +159,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(MaxGCPauseMillis, 650);
+    FLAG_SET_CMDLINE(MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {

--- a/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/vm_version_loongarch.cpp
@@ -159,7 +159,7 @@ void VM_Version::get_processor_features() {
   _supports_cx8 = true;
 
   if (UseG1GC && FLAG_IS_DEFAULT(MaxGCPauseMillis)) {
-    FLAG_SET_CMDLINE(MaxGCPauseMillis, 150);
+    FLAG_SET_DEFAULT(MaxGCPauseMillis, 150);
   }
 
   if (supports_lsx()) {


### PR DESCRIPTION
32519: Fix for 31967 set default MaxGCPauseMillis
31967: [G1GC] Set default MaxGCPauseMillis=150ms
32446: Fix the error of assert(v_align > 1) when MaxVectorSize is 4 or 8