### PR TITLE
Update (2024.01.26)

### DIFF
--- a/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/shenandoah/shenandoah_loongarch_64.ad
@@ -29,16 +29,16 @@ source_hpp %{
 %}
 
 encode %{
-  enc_class loongarch_enc_cmpxchg_oop_shenandoah(memory mem, mRegP oldval, mRegP newval, mRegI res) %{
+  enc_class loongarch_enc_cmpxchg_oop_shenandoah(indirect mem, mRegP oldval, mRegP newval, mRegI res) %{
     MacroAssembler _masm(&cbuf);
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
 
-  enc_class loongarch_enc_cmpxchg_acq_oop_shenandoah(memory mem, mRegP oldval, mRegP newval, mRegI res) %{
+  enc_class loongarch_enc_cmpxchg_acq_oop_shenandoah(indirect mem, mRegP oldval, mRegP newval, mRegI res) %{
     MacroAssembler _masm(&cbuf);
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
@@ -64,7 +64,7 @@ instruct compareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, mRegN
   %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
@@ -92,7 +92,7 @@ instruct compareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval, mR
  %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
@@ -108,7 +108,7 @@ instruct compareAndExchangeN_shenandoah(mRegN res, indirect mem, mRegN oldval, m
   %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
@@ -124,7 +124,7 @@ instruct compareAndExchangeP_shenandoah(mRegP res, indirect mem, mRegP oldval, m
   %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ true, $res$$Register);
   %}
@@ -140,7 +140,7 @@ instruct compareAndExchangeNAcq_shenandoah(mRegN res, indirect mem, mRegN oldval
   %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
@@ -156,7 +156,7 @@ instruct compareAndExchangePAcq_shenandoah(mRegP res, indirect mem, mRegP oldval
   %}
 
   ins_encode %{
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ true, $res$$Register);
   %}
@@ -172,7 +172,7 @@ instruct weakCompareAndSwapN_shenandoah(mRegI res, indirect mem, mRegN oldval, m
   %}
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
@@ -189,7 +189,7 @@ instruct weakCompareAndSwapP_shenandoah(mRegI res, indirect mem, mRegP oldval, m
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ false, /*is_cae*/ false, $res$$Register);
   %}
@@ -206,7 +206,7 @@ instruct weakCompareAndSwapNAcq_shenandoah(mRegI res, indirect mem, mRegN oldval
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}
@@ -223,7 +223,7 @@ instruct weakCompareAndSwapPAcq_shenandoah(mRegI res, indirect mem, mRegP oldval
 
   ins_encode %{
     // Weak is not currently supported by ShenandoahBarrierSet::cmpxchg_oop
-    Address  addr(as_Register($mem$$base), $mem$$disp);
+    Address  addr(as_Register($mem$$base), 0);
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, addr, $oldval$$Register, $newval$$Register,
                                                    /*acquire*/ true, /*is_cae*/ false, $res$$Register);
   %}

--- a/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/gc/x/x_loongarch_64.ad
@@ -56,12 +56,12 @@ static void x_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
   // Weak CAS operations are thus only emitted if the barrier is elided.
   Address addr(mem);
   if (node->barrier_data() == XLoadBarrierElided) {
-    __ cmpxchg(addr, oldval, newval, tmp, false /* retold */, acquire /* barrier */,
+    __ cmpxchg(addr, oldval, newval, tmp, false /* retold */, acquire /* acquire */,
                weak /* weak */, false /* exchange */);
     __ move(res, tmp);
   } else {
     __ move(tmp, oldval);
-    __ cmpxchg(addr, tmp, newval, AT, true /* retold */, acquire /* barrier */,
+    __ cmpxchg(addr, tmp, newval, AT, true /* retold */, acquire /* acquire */,
                false /* weak */, false /* exchange */);
     __ move(res, AT);
 
@@ -70,7 +70,7 @@ static void x_compare_and_swap(MacroAssembler& _masm, const MachNode* node,
     __ andr(AT, AT, tmp);
     __ beqz(AT, good);
     x_load_barrier_slow_path(_masm, node, addr, tmp, res /* used as tmp */);
-    __ cmpxchg(addr, oldval, newval, tmp, false /* retold */, acquire /* barrier */, weak /* weak */, false /* exchange */);
+    __ cmpxchg(addr, oldval, newval, tmp, false /* retold */, acquire /* acquire */, weak /* weak */, false /* exchange */);
     __ move(res, tmp);
     __ bind(good);
   }

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -10849,6 +10849,28 @@ instruct convHF2F_reg_reg(regF dst, mRegI src, regF tmp) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct round_float_reg(mRegI dst, regF src, mRegL tmp)
+%{
+  match(Set dst (RoundF src));
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "round_float $dst, $src\t# @round_float_reg" %}
+  ins_encode %{
+    __ java_round_float($dst$$Register, $src$$FloatRegister, $tmp$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct round_double_reg(mRegL dst, regD src, mRegL tmp)
+%{
+  match(Set dst (RoundD src));
+  effect(TEMP_DEF dst, TEMP tmp);
+  format %{ "round_double $dst, $src\t# @round_double_reg" %}
+  ins_encode %{
+    __ java_round_double($dst$$Register, $src$$FloatRegister, $tmp$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 instruct roundD(regD dst, regD src, immI rmode) %{
   predicate(UseLSX);
   match(Set dst (RoundDoubleMode src rmode));
@@ -12692,26 +12714,6 @@ instruct safePoint_poll_tls(mRegP poll) %{
   ins_pipe( pipe_serial );
 %}
 
-//----------Arithmetic Conversion Instructions---------------------------------
-
-instruct roundFloat_nop(regF dst)
-%{
-  match(Set dst (RoundFloat dst));
-
-  ins_cost(0);
-  ins_encode();
-  ins_pipe( empty );
-%}
-
-instruct roundDouble_nop(regD dst)
-%{
-  match(Set dst (RoundDouble dst));
-
-  ins_cost(0);
-  ins_encode();
-  ins_pipe( empty );
-%}
-
 //----------BSWAP Instructions-------------------------------------------------
 instruct bytes_reverse_int(mRegI dst, mRegIorL2I src) %{
   match(Set dst (ReverseBytesI src));
@@ -14395,6 +14397,64 @@ instruct reduceVD(regD dst, regD src, vReg vsrc, vReg tmp) %{
   ins_encode %{
     __ reduce($dst$$FloatRegister, $src$$FloatRegister, $vsrc$$FloatRegister, $tmp$$FloatRegister,
               T_DOUBLE, this->ideal_Opcode(), Matcher::vector_length_in_bytes(this, $vsrc));
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+// ------------------------------ Vector Round ---------------------------------
+
+instruct round_float_lsx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
+  predicate(Matcher::vector_length_in_bytes(n) <= 16);
+  match(Set dst (RoundVF src));
+  effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
+  format %{ "round_float_lsx $dst, $src\t# @round_float_lsx" %}
+  ins_encode %{
+    __ java_round_float_lsx($dst$$FloatRegister,
+                            $src$$FloatRegister,
+                            $vtemp1$$FloatRegister,
+                            $vtemp2$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct round_float_lasx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
+  predicate(Matcher::vector_length_in_bytes(n) > 16);
+  match(Set dst (RoundVF src));
+  effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
+  format %{ "round_float_lasx $dst, $src\t# @round_float_lasx" %}
+  ins_encode %{
+    __ java_round_float_lasx($dst$$FloatRegister,
+                             $src$$FloatRegister,
+                             $vtemp1$$FloatRegister,
+                             $vtemp2$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct round_double_lsx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
+  predicate(Matcher::vector_length_in_bytes(n) <= 16);
+  match(Set dst (RoundVD src));
+  effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
+  format %{ "round_double_lsx $dst, $src\t# @round_double_lsx" %}
+  ins_encode %{
+    __ java_round_double_lsx($dst$$FloatRegister,
+                             $src$$FloatRegister,
+                             $vtemp1$$FloatRegister,
+                             $vtemp2$$FloatRegister);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct round_double_lasx(vReg dst, vReg src, vReg vtemp1, vReg vtemp2) %{
+  predicate(Matcher::vector_length_in_bytes(n) > 16);
+  match(Set dst (RoundVD src));
+  effect(TEMP_DEF dst, TEMP vtemp1, TEMP vtemp2);
+  format %{ "round_double_lasx $dst, $src\t# @round_double_lasx" %}
+  ins_encode %{
+    __ java_round_double_lasx($dst$$FloatRegister,
+                              $src$$FloatRegister,
+                              $vtemp1$$FloatRegister,
+                              $vtemp2$$FloatRegister);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -981,6 +981,8 @@ const bool Matcher::match_rule_supported(int opcode) {
     case Op_ConvF2HF:
     case Op_ConvHF2F:
     case Op_StrInflatedCopy:
+    case Op_StrCompressedCopy:
+    case Op_EncodeISOArray:
       if (!UseLSX)
         return false;
     case Op_PopCountI:
@@ -8789,19 +8791,25 @@ instruct count_positives(mRegP src, mRegI len, mRegI result,
 %}
 
 // fast char[] to byte[] compression
-instruct string_compress(a4_RegP src, a5_RegP dst, mA6RegI len, mRegI result,
-                         mRegL tmp1, mRegL tmp2, mRegL tmp3)
+instruct string_compress(a2_RegP src, mRegP dst, mRegI len, mRegI result,
+                         mRegL tmp1, mRegL tmp2, mRegL tmp3,
+                         regF vtemp1, regF vtemp2, regF vtemp3, regF vtemp4)
 %{
+  predicate(UseLSX);
   match(Set result (StrCompressedCopy src (Binary dst len)));
-  effect(USE_KILL src, USE_KILL dst, USE_KILL len, TEMP_DEF result,
-         TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP tmp2, TEMP tmp3,
+         TEMP vtemp1, TEMP vtemp2, TEMP vtemp3, TEMP vtemp4, USE_KILL src);
 
   format %{ "String Compress $src,$dst -> $result @ string_compress " %}
+
   ins_encode %{
     __ char_array_compress($src$$Register, $dst$$Register, $len$$Register,
                            $result$$Register, $tmp1$$Register,
-                           $tmp2$$Register, $tmp3$$Register);
+                           $tmp2$$Register, $tmp3$$Register,
+                           $vtemp1$$FloatRegister, $vtemp2$$FloatRegister,
+                           $vtemp3$$FloatRegister, $vtemp4$$FloatRegister);
   %}
+
   ins_pipe( pipe_slow );
 %}
 
@@ -8872,38 +8880,46 @@ instruct array_equalsC(a4_RegP ary1, a5_RegP ary2, mRegI result, mRegL tmp0, mRe
 %}
 
 // encode char[] to byte[] in ISO_8859_1
-instruct encode_iso_array(a4_RegP src, a5_RegP dst, mA6RegI len, mRegI result,
-                          mRegL tmp1, mRegL tmp2, mRegL tmp3)
+instruct encode_iso_array(a2_RegP src, mRegP dst, mRegI len, mRegI result,
+                          mRegL tmp1, mRegL tmp2, mRegL tmp3,
+                          regF vtemp1, regF vtemp2, regF vtemp3, regF vtemp4)
 %{
-  predicate(!((EncodeISOArrayNode*)n)->is_ascii());
+  predicate(UseLSX && !((EncodeISOArrayNode*)n)->is_ascii());
   match(Set result (EncodeISOArray src (Binary dst len)));
-  effect(USE_KILL src, USE_KILL dst, USE_KILL len, TEMP_DEF result,
-         TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP tmp2, TEMP tmp3,
+         TEMP vtemp1, TEMP vtemp2, TEMP vtemp3, TEMP vtemp4, USE_KILL src);
 
   format %{ "Encode ISO array $src,$dst,$len -> $result @ encode_iso_array" %}
+
   ins_encode %{
     __ encode_iso_array($src$$Register, $dst$$Register, $len$$Register,
                         $result$$Register, $tmp1$$Register,
-                        $tmp2$$Register, $tmp3$$Register, false);
+                        $tmp2$$Register, $tmp3$$Register, false,
+                        $vtemp1$$FloatRegister, $vtemp2$$FloatRegister,
+                        $vtemp3$$FloatRegister, $vtemp4$$FloatRegister);
   %}
 
   ins_pipe( pipe_slow );
 %}
 
 // encode char[] to byte[] in ASCII
-instruct encode_ascii_array(a4_RegP src, a5_RegP dst, mA6RegI len, mRegI result,
-                            mRegL tmp1, mRegL tmp2, mRegL tmp3)
+instruct encode_ascii_array(a2_RegP src, mRegP dst, mRegI len, mRegI result,
+                            mRegL tmp1, mRegL tmp2, mRegL tmp3,
+                            regF vtemp1, regF vtemp2, regF vtemp3, regF vtemp4)
 %{
-  predicate(((EncodeISOArrayNode*)n)->is_ascii());
+  predicate(UseLSX && ((EncodeISOArrayNode*)n)->is_ascii());
   match(Set result (EncodeISOArray src (Binary dst len)));
-  effect(USE_KILL src, USE_KILL dst, USE_KILL len, TEMP_DEF result,
-         TEMP tmp1, TEMP tmp2, TEMP tmp3);
+  effect(TEMP_DEF result, TEMP tmp1, TEMP tmp2, TEMP tmp3,
+         TEMP vtemp1, TEMP vtemp2, TEMP vtemp3, TEMP vtemp4, USE_KILL src);
 
   format %{ "Encode ASCII array $src,$dst,$len -> $result @ encode_ascii_array" %}
+
   ins_encode %{
     __ encode_iso_array($src$$Register, $dst$$Register, $len$$Register,
                         $result$$Register, $tmp1$$Register,
-                        $tmp2$$Register, $tmp3$$Register, true);
+                        $tmp2$$Register, $tmp3$$Register, true,
+                        $vtemp1$$FloatRegister, $vtemp2$$FloatRegister,
+                        $vtemp3$$FloatRegister, $vtemp4$$FloatRegister);
   %}
 
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -315,6 +315,18 @@ class MacroAssembler: public Assembler {
   void sign_extend_short(Register reg) { ext_w_h(reg, reg); }
   void sign_extend_byte(Register reg)  { ext_w_b(reg, reg); }
 
+  // java.lang.Math::round intrinsics
+  void java_round_float(Register dst, FloatRegister src, Register tmp);
+  void java_round_float_lsx(FloatRegister dst, FloatRegister src,
+                            FloatRegister vtemp1, FloatRegister vtemp2);
+  void java_round_float_lasx(FloatRegister dst, FloatRegister src,
+                             FloatRegister vtemp1, FloatRegister vtemp2);
+  void java_round_double(Register dst, FloatRegister src, Register tmp);
+  void java_round_double_lsx(FloatRegister dst, FloatRegister src,
+                             FloatRegister vtemp1, FloatRegister vtemp2);
+  void java_round_double_lasx(FloatRegister dst, FloatRegister src,
+                              FloatRegister vtemp1, FloatRegister vtemp2);
+
   // allocation
   void tlab_allocate(
     Register obj,                      // result: pointer to object after successful allocation

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -673,9 +673,11 @@ class MacroAssembler: public Assembler {
                        Register tmp1, Register tmp2);
 
   // Code for java.lang.StringUTF16::compress intrinsic.
-  void char_array_compress(Register src, Register dst, Register len,
-                           Register result, Register tmp1,
-                           Register tmp2, Register tmp3);
+  void char_array_compress(Register src, Register dst,
+                           Register len, Register result,
+                           Register tmp1, Register tmp2, Register tmp3,
+                           FloatRegister vtemp1, FloatRegister vtemp2,
+                           FloatRegister vtemp3, FloatRegister vtemp4);
 
   // Code for java.lang.StringLatin1::inflate intrinsic.
   void byte_array_inflate(Register src, Register dst, Register len,
@@ -687,7 +689,9 @@ class MacroAssembler: public Assembler {
   void encode_iso_array(Register src, Register dst,
                         Register len, Register result,
                         Register tmp1, Register tmp2,
-                        Register tmp3, bool ascii);
+                        Register tmp3, bool ascii,
+                        FloatRegister vtemp1, FloatRegister vtemp2,
+                        FloatRegister vtemp3, FloatRegister vtemp4);
 
   // Code for java.math.BigInteger::mulAdd intrinsic.
   void mul_add(Register out, Register in, Register offset,

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -61,6 +61,8 @@ class la {
   static address _jlong_fill;
   static address _arrayof_jlong_fill;
 
+  static julong _string_compress_index[];
+
   // begin trigonometric tables block. See comments in .cpp file
   static juint    _npio2_hw[];
   static jdouble   _two_over_pi[];
@@ -95,6 +97,10 @@ public:
 
   static address arrayof_jlong_fill() {
     return _arrayof_jlong_fill;
+  }
+
+  static address string_compress_index() {
+    return (address) _string_compress_index;
   }
 };
 

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch.hpp
@@ -63,6 +63,9 @@ class la {
 
   static julong _string_compress_index[];
 
+  static jfloat _round_float_imm[];
+  static jdouble _round_double_imm[];
+
   // begin trigonometric tables block. See comments in .cpp file
   static juint    _npio2_hw[];
   static jdouble   _two_over_pi[];
@@ -101,6 +104,14 @@ public:
 
   static address string_compress_index() {
     return (address) _string_compress_index;
+  }
+
+  static address round_float_imm() {
+    return (address) _round_float_imm;
+  }
+
+  static address round_double_imm() {
+    return (address) _round_double_imm;
   }
 };
 

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -186,3 +186,13 @@ ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_pio2[] = {
   2.73370053816464559624e-44, // 0x36E3822280000000
   2.16741683877804819444e-51, // 0x3569F31D00000000
 };
+
+ATTRIBUTE_ALIGNED(64) jfloat StubRoutines::la::_round_float_imm[] = {
+  0.49999997f, // round positive
+  0.5f,        // round negative
+};
+
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_round_double_imm[] = {
+  0.49999999999999994d, // round positive
+  0.5d,                 // round negative
+};

--- a/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/stubRoutines_loongarch_64.cpp
@@ -151,6 +151,10 @@ ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::la::_dcos_coef[] = {
     -1.13596475577881948265e-11  // 0xBDA8FAE9BE8838D4
 };
 
+ATTRIBUTE_ALIGNED(128) julong StubRoutines::la::_string_compress_index[] = {
+    0x0e0c0a0806040200UL, 0x1e1c1a1816141210UL // 128-bit shuffle index
+};
+
 // Table of constants for 2/pi, 396 Hex digits (476 decimal) of 2/pi.
 // Used in cases of very large argument. 396 hex digits is enough to support
 // required precision.

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3476,7 +3476,6 @@ void TemplateTable::invokeinterface(int byte_no) {
 
   __ bind(no_such_method);
   // throw exception
-  __ pop(Rmethod);           // pop return address (pushed by prepare_invoke)
   __ restore_bcp();
   __ restore_locals();
   // Pass arguments for generating a verbose error message.
@@ -3490,7 +3489,6 @@ void TemplateTable::invokeinterface(int byte_no) {
 
   __ bind(no_such_interface);
   // throw exception
-  __ pop(Rmethod);           // pop return address (pushed by prepare_invoke)
   __ restore_bcp();
   __ restore_locals();
   // Pass arguments for generating a verbose error message.

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -22,6 +22,12 @@
  *
  */
 
+/*
+ * This file has been modified by Loongson Technology in 2023, These
+ * modifications are Copyright (c) 2023, Loongson Technology, and are made
+ * available on the same license terms set forth above.
+ */
+
 #include "precompiled.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/oopStorage.hpp"
@@ -365,6 +371,9 @@ bool ObjectMonitor::enter(JavaThread* current) {
   }
 
   assert(owner_raw() != current, "invariant");
+  // Thread _succ != current assertion load reording before Thread if (_succ == current) _succ = nullptr.
+  // But expect order is firstly if (_succ == current) _succ = nullptr then _succ != current assertion.
+  LOONGARCH64_ONLY(DEBUG_ONLY(__asm__ __volatile__ ("dbar 0x700\n");))
   assert(_succ != current, "invariant");
   assert(!SafepointSynchronize::is_at_safepoint(), "invariant");
   assert(current->thread_state() != _thread_blocked, "invariant");
@@ -729,6 +738,7 @@ void ObjectMonitor::EnterI(JavaThread* current) {
   }
 
   // The Spin failed -- Enqueue and park the thread ...
+  LOONGARCH64_ONLY(DEBUG_ONLY(__asm__ __volatile__ ("dbar 0x700\n");))
   assert(_succ != current, "invariant");
   assert(owner_raw() != current, "invariant");
   assert(_Responsible != current, "invariant");


### PR DESCRIPTION
24527: Fix a typo for invokeinterface in #8604
29494: Fix assert(_succ != current) failed: invariant
32874: Amend 30985: Insert acqure membar for load-exclusive with acquire to fix typo
29823: Fix ShenandoahGC cmpxchg_oop register be clobbered issue
32796: Rethinking the ties-to-positive round mode
32688: Revamp the SIMD string compress routines