### PR TITLE
Update (2024.01.29)

### DIFF
--- a/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/c1_MacroAssembler_loongarch_64.cpp
@@ -61,7 +61,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // Load object header
   ld_d(hdr, Address(obj, hdr_offset));
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(obj, hdr, SCR1, SCR2, slow_case);
+    lightweight_lock(obj, hdr, SCR1, SCR2, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     Label done;
     // and mark it as unlocked
@@ -125,7 +125,7 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
     // be encoded.
     andi(AT, hdr, markWord::monitor_value);
     bnez(AT, slow_case);
-    fast_unlock(obj, hdr, SCR1, SCR2, slow_case);
+    lightweight_unlock(obj, hdr, SCR1, SCR2, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     // test if object header is pointing to the displaced header, and if so, restore
     // the displaced header in the object - if the object header is not pointing to

--- a/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/c2_MacroAssembler_loongarch.cpp
@@ -93,7 +93,7 @@ void C2_MacroAssembler::fast_lock_c2(Register oop, Register box, Register flag,
     b(cont);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-    fast_lock(oop, disp_hdr, flag, SCR1, no_count);
+    lightweight_lock(oop, disp_hdr, flag, SCR1, no_count);
     b(count);
   }
 
@@ -170,7 +170,7 @@ void C2_MacroAssembler::fast_unlock_c2(Register oop, Register box, Register flag
     b(cont);
   } else {
     assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-    fast_unlock(oop, tmp, flag, box, no_count);
+    lightweight_unlock(oop, tmp, flag, box, no_count);
     b(count);
   }
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -822,7 +822,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
 
     if (LockingMode == LM_LIGHTWEIGHT) {
       ld_d(tmp_reg, Address(scr_reg, oopDesc::mark_offset_in_bytes()));
-      fast_lock(scr_reg, tmp_reg, SCR1, SCR2, slow_case);
+      lightweight_lock(scr_reg, tmp_reg, SCR1, SCR2, slow_case);
       b(count);
     } else if (LockingMode == LM_LEGACY) {
       // Load (object->mark() | 1) into tmp_reg
@@ -923,7 +923,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
       ld_d(hdr_reg, Address(scr_reg, oopDesc::mark_offset_in_bytes()));
       andi(AT, hdr_reg, markWord::monitor_value);
       bnez(AT, slow_case);
-      fast_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
+      lightweight_unlock(scr_reg, hdr_reg, tmp_reg, SCR1, slow_case);
       b(count);
       bind(slow_case);
     } else if (LockingMode == LM_LEGACY) {

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -769,6 +769,12 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
     // testing if reserved zone needs to be re-enabled
     Label no_reserved_zone_enabling;
 
+    // check if already enabled - if so no re-enabling needed
+    assert(sizeof(StackOverflow::StackGuardState) == 4, "unexpected size");
+    ld_w(AT, Address(TREG, JavaThread::stack_guard_state_offset()));
+    addi_w(AT, AT, StackOverflow::stack_guard_enabled);
+    beqz(AT, no_reserved_zone_enabling);
+
     ld_d(AT, Address(TREG, JavaThread::reserved_stack_activation_offset()));
     bge(AT, Rsender, no_reserved_zone_enabling);
 

--- a/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/interp_masm_loongarch_64.cpp
@@ -706,7 +706,7 @@ void InterpreterMacroAssembler::remove_activation(TosState state,
   // Check that all monitors are unlocked
   {
     Label loop, exception, entry, restart;
-    const int entry_size = frame::interpreter_frame_monitor_size() * wordSize;
+    const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
     const Address monitor_block_top(FP,
         frame::interpreter_frame_monitor_block_top_offset * wordSize);
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.cpp
@@ -4091,7 +4091,7 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
   }
 }
 
-// Implements fast-locking.
+// Implements lightweight-locking.
 // Branches to slow upon failure to lock the object.
 // Falls through upon success.
 //
@@ -4099,7 +4099,7 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
 //  - hdr: the header, already loaded from obj, will be destroyed
 //  - flag: as cr for c2, but only as temporary regisgter for c1/interpreter
 //  - tmp: temporary registers, will be destroyed
-void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
+void MacroAssembler::lightweight_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, flag, tmp);
 
@@ -4124,7 +4124,7 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Regist
   st_w(tmp, Address(TREG, JavaThread::lock_stack_top_offset()));
 }
 
-// Implements fast-unlocking.
+// Implements lightweight-unlocking.
 // Branches to slow upon failure.
 // Falls through upon success.
 //
@@ -4132,7 +4132,7 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register flag, Regist
 // - hdr: the (pre-loaded) header of the object
 // - flag: as cr for c2, but only as temporary regisgter for c1/interpreter
 // - tmp: temporary registers
-void MacroAssembler::fast_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
+void MacroAssembler::lightweight_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow) {
   assert(LockingMode == LM_LIGHTWEIGHT, "only used with new lightweight locking");
   assert_different_registers(obj, hdr, tmp, flag);
 

--- a/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
+++ b/src/hotspot/cpu/loongarch/macroAssembler_loongarch.hpp
@@ -741,8 +741,8 @@ class MacroAssembler: public Assembler {
     }
   }
 
-  void fast_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
-  void fast_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+  void lightweight_lock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
+  void lightweight_unlock(Register obj, Register hdr, Register flag, Register tmp, Label& slow);
 
 #if INCLUDE_ZGC
   void patchable_li16(Register rd, uint16_t value);

--- a/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/sharedRuntime_loongarch_64.cpp
@@ -1762,7 +1762,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ ld_d(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       // FIXME
       Register tmp = T1;
-      __ fast_lock(obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
+      __ lightweight_lock(obj_reg, swap_reg, tmp, SCR1, slow_path_lock);
     }
 
     __ bind(count);
@@ -1925,7 +1925,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ ld_d(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       __ andi(AT, lock_reg, markWord::monitor_value);
       __ bnez(AT, slow_path_unlock);
-      __ fast_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
+      __ lightweight_unlock(obj_reg, lock_reg, swap_reg, SCR1, slow_path_unlock);
       __ decrement(Address(TREG, JavaThread::held_monitor_count_offset()));
     }
 

--- a/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/templateInterpreterGenerator_loongarch.cpp
@@ -774,7 +774,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // generate_method_entry) so the guard should work for them too.
   //
 
-  const int entry_size    = frame::interpreter_frame_monitor_size() * wordSize;
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
   // total overhead size: entry_size + (saved fp thru expr stack bottom).
   // be sure to change this if you add/subtract anything to/from the overhead area
@@ -841,7 +841,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
 // Rmethod - Method*
 void TemplateInterpreterGenerator::lock_method(void) {
   // synchronize method
-  const int entry_size = frame::interpreter_frame_monitor_size() * wordSize;
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
 #ifdef ASSERT
   { Label L;

--- a/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
+++ b/src/hotspot/cpu/loongarch/templateTable_loongarch_64.cpp
@@ -3872,7 +3872,7 @@ void TemplateTable::monitorenter() {
 
   const Address monitor_block_top(FP, frame::interpreter_frame_monitor_block_top_offset
       * wordSize);
-  const int entry_size = (frame::interpreter_frame_monitor_size()* wordSize);
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
   Label allocated;
 
   const Register monitor_reg = T0;
@@ -3947,7 +3947,7 @@ void TemplateTable::monitorexit() {
 
   __ null_check(FSR);
 
-  const int entry_size =(frame::interpreter_frame_monitor_size()* wordSize);
+  const int entry_size = frame::interpreter_frame_monitor_size_in_bytes();
 
   const Register monitor_top = T0;
   const Register monitor_bot = T2;

--- a/test/hotspot/jtreg/loongson/25064/NUMAHelper.java
+++ b/test/hotspot/jtreg/loongson/25064/NUMAHelper.java
@@ -56,8 +56,7 @@ public class NUMAHelper {
     }
 
     static OutputAnalyzer invokeJvm(String... args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(args);
-        return new OutputAnalyzer(pb.start());
+        return new OutputAnalyzer(ProcessTools.createTestJvm(args).start());
     }
 
     static int getNUMANodes() throws Exception {

--- a/test/hotspot/jtreg/loongson/30358/TestLoadLoad.java
+++ b/test/hotspot/jtreg/loongson/30358/TestLoadLoad.java
@@ -47,7 +47,7 @@ public class TestLoadLoad {
         command.add("-XX:+PrintInterpreter");
         command.add("-version");
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
         analyzer.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/loongson/30358/TestNewObjectWithFinal.java
+++ b/test/hotspot/jtreg/loongson/30358/TestNewObjectWithFinal.java
@@ -70,7 +70,7 @@ public class TestNewObjectWithFinal {
         command.add("-XX:CompileCommand=compileonly," + Launcher.class.getName() + "::" + "test");
         command.add(Launcher.class.getName());
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
         analyzer.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/loongson/30358/TestVolatile.java
+++ b/test/hotspot/jtreg/loongson/30358/TestVolatile.java
@@ -74,7 +74,7 @@ public class TestVolatile {
         command.add("-XX:CompileCommand=dontinline," + Launcher.class.getName() + "::" + "*");
         command.add(Launcher.class.getName());
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(command);
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 


### PR DESCRIPTION
32358: LA port of 8310596: Utilize existing method frame::interpreter_frame_monitor_size_in_bytes()
31534: LA port of 8309209: C2 failed "assert(_stack_guard_state == stack_guard_reserved_disabled) failed: inconsistent state"
32616: LA port of 8316179: Use consistent naming for lightweight locking in MacroAssembler