### PR TITLE
Update (2025.02.08)

### DIFF
--- a/src/hotspot/cpu/loongarch/frame_loongarch.cpp
+++ b/src/hotspot/cpu/loongarch/frame_loongarch.cpp
@@ -60,8 +60,11 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // unextended sp must be within the stack and above or equal sp
-  if (!thread->is_in_stack_range_incl(unextended_sp, sp)) {
+  // unextended sp must be within the stack
+  // Note: sp can be greater than unextended_sp in the case of
+  // interpreted -> interpreted calls that go through a method handle linker,
+  // since those pop the last argument (the appendix) from the stack.
+  if (!thread->is_in_stack_range_incl(unextended_sp, sp - Interpreter::stackElementSize)) {
     return false;
   }
 

--- a/src/hotspot/cpu/loongarch/loongarch_64.ad
+++ b/src/hotspot/cpu/loongarch/loongarch_64.ad
@@ -15751,6 +15751,39 @@ instruct signumV(vReg dst, vReg src, vReg zero, vReg one, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}
 
+// ------------------------------ ReverseBytesV --------------------------------
+
+instruct reverseBytesV(vReg dst, vReg src) %{
+  match(Set dst (ReverseBytesV src));
+  format %{ "(x)vreverse_byte    $dst, $src\t# @reverseBytesV" %}
+  ins_encode %{
+    if (Matcher::vector_length_in_bytes(this) > 16) {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : if ($dst$$FloatRegister != $src$$FloatRegister)
+                       __ xvori_b($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+        case T_SHORT : __ xvshuf4i_b($dst$$FloatRegister, $src$$FloatRegister, 0b10110001); break;
+        case T_INT   : __ xvshuf4i_b($dst$$FloatRegister, $src$$FloatRegister, 0b00011011); break;
+        case T_LONG  : __ xvshuf4i_w($dst$$FloatRegister, $src$$FloatRegister, 0b10110001);
+                       __ xvshuf4i_b($dst$$FloatRegister, $dst$$FloatRegister, 0b00011011); break;
+        default:
+          ShouldNotReachHere();
+      }
+    } else {
+      switch (Matcher::vector_element_basic_type(this)) {
+        case T_BYTE  : if ($dst$$FloatRegister != $src$$FloatRegister)
+                       __ vori_b($dst$$FloatRegister, $src$$FloatRegister, 0); break;
+        case T_SHORT : __ vshuf4i_b($dst$$FloatRegister, $src$$FloatRegister, 0b10110001); break;
+        case T_INT   : __ vshuf4i_b($dst$$FloatRegister, $src$$FloatRegister, 0b00011011); break;
+        case T_LONG  : __ vshuf4i_w($dst$$FloatRegister, $src$$FloatRegister, 0b10110001);
+                       __ vshuf4i_b($dst$$FloatRegister, $dst$$FloatRegister, 0b00011011); break;
+        default:
+          ShouldNotReachHere();
+      }
+    }
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 
 //----------PEEPHOLE RULES-----------------------------------------------------
 // These must follow all instruction definitions as they use the names

--- a/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * This file has been modified by Loongson Technology in 2023, These
- * modifications are Copyright (c) 2023, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
 /**
  * @test
  * @bug 8283894
@@ -37,8 +31,7 @@
  *            (vm.cpu.features ~= ".*bmi2.*" & vm.cpu.features ~= ".*bmi1.*" &
  *             vm.cpu.features ~= ".*sse2.*")) |
  *            ((vm.opt.UseSVE == "null" | vm.opt.UseSVE > 1) &
- *             os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*") |
- *             os.arch=="loongarch64")
+ *             os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*"))
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestBitShuffleOpers
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -21,20 +21,13 @@
  * questions.
  */
 
-/*
- * This file has been modified by Loongson Technology in 2023, These
- * modifications are Copyright (c) 2023, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
 /**
 * @test
 * @key randomness
 * @summary Test vectorization of numberOfTrailingZeros/numberOfLeadingZeros for Long
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0)) |
-*           (os.simpleArch == "loongarch64")
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*" & (vm.opt.UseSVE == "null" | vm.opt.UseSVE > 0))
 * @library /test/lib /
 * @run driver compiler.vectorization.TestNumberOfContinuousZeros
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBitsVector.java
@@ -20,19 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-/*
- * This file has been modified by Loongson Technology in 2023, These
- * modifications are Copyright (c) 2023, Loongson Technology, and are made
- * available on the same license terms set forth above.
- */
-
 /**
  * @test
  * @bug 8290034
  * @summary Auto-vectorization of Reverse bit operation.
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64" | os.arch=="loongarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") | os.arch == "aarch64"
  * @library /test/lib /
  * @run driver compiler.vectorization.TestReverseBitsVector
  */


### PR DESCRIPTION
30722: AsyncGetCallTrace obtains too few frames while testing ASGCTBaseTest.java
30719: Revert TestReverseBitsVector.java
30716: Revert TestNumberOfContinuousZeros.java
30720: Implement ReverseBytesV
30708: Revert TestBitShuffleOpers.java